### PR TITLE
Clearer error message if weather data is not found

### DIFF
--- a/lib/google_weather/data.rb
+++ b/lib/google_weather/data.rb
@@ -12,8 +12,12 @@ class GoogleWeather
     end
     
     def inspect
-      data = @data.inject([]) { |collection, key| collection << "#{key[0]}: #{key[1]['data']}"; collection }.join("\n    ")
-      "#<#{self.class}:0x#{object_id}\n    #{data}>"
+      begin
+        data = @data.inject([]) { |collection, key| collection << "#{key[0]}: #{key[1]['data']}"; collection }.join("\n    ")
+        "#<#{self.class}:0x#{object_id}\n    #{data}>"
+      rescue
+        "No weather information found for the specified location."
+      end
     end
   end
   


### PR DESCRIPTION
I ran into a problem where I fatfingered my zip code during testing, and the error message when you ask for the `current_conditions` of a bad zip code is "object does not respond to #inspect".  I spent a little time troubleshooting before I realized the problem was in my location input.

This pull request adds a very simple rescue clause to the end of Data#inspect to clear up the nature of the problem without actually raising an exception.  It's a small change, but it might save someone down the road a few minutes of troubleshooting time.
